### PR TITLE
removed-validation-logic-while-saving-pass

### DIFF
--- a/src/components/Manager.jsx
+++ b/src/components/Manager.jsx
@@ -108,11 +108,12 @@ const Manager = () => {
       errors.push("Error: Username must be at least 3 characters long.");
     }
 
-    // Validate Password
-    const passwordValidationResult = validatePassword(form.password);
-    if (!passwordValidationResult) {
-      errors.push("Error: Password does not meet the required criteria.");
-    }
+    // PASSWORD VALIDATION NOT REQUIRED AS THE PASSWORD HAS ALREADY BEEN CREATED BY USER JUST NEEDED TO BE SAVED
+
+    // const passwordValidationResult = validatePassword(form.password);
+    // if (!passwordValidationResult) {
+    //   errors.push("Error: Password does not meet the required criteria.");
+    // }
 
     // If there are errors, show them in toast and return
     if (errors.length > 0) {


### PR DESCRIPTION
 This pull request addresses an issue where the application incorrectly enforced input validation rules when storing existing passwords. Users were forced to modify valid passwords that were created prior to the implementation of the current validation criteria. This led to unnecessary complications, particularly when integrating with other services or trying to remember passwords.

Changes Made:

1.Removed the input validation logic that checked existing passwords when they were being stored.
2.Ensured that the application now accepts previously created passwords without applying current validation rules.


